### PR TITLE
added namespace into build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace("com.droidsonroids.add_to_google_wallet")
+    }
+
     compileSdk 34
 
     compileOptions {


### PR DESCRIPTION
need add namespace when using Android Gradle Plugin (AGP) version 8.1 or higher